### PR TITLE
added mark down to html in chat message

### DIFF
--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import React, { Suspense } from 'react';
 import Linkify from 'react-linkify';
 
 import Attachment from '../Attachment/Attachment';
@@ -24,6 +24,38 @@ interface IMessage {
   sameAuthorAsPrevious: boolean;
 }
 
+function markdownToHtml(text: string): string {
+  // Convert bold text (e.g., *bold*)
+  text = text.replace(/\*(.*?)\*/g, '<strong>$1</strong>');
+
+  // Convert italic text (e.g., _italic_)
+  text = text.replace(/_(.*?)_/g, '<em>$1</em>');
+
+  // Convert headers (e.g., # Header)
+  text = text.replace(/^### (.*$)/gim, '<h3>$1</h3>');
+  text = text.replace(/^## (.*$)/gim, '<h2>$1</h2>');
+  text = text.replace(/^# (.*$)/gim, '<h1>$1</h1>');
+
+  // Convert links (e.g., [title](http://example.com))
+  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+
+  // Convert unordered lists (e.g., * item)
+  text = text.replace(/^\* (.*)$/gm, '<ul><li>$1</li></ul>');
+  text = text.replace(/<\/ul>\n<ul>/g, ''); // Fix consecutive <ul> tags
+
+  // Convert ordered lists (e.g., 1. item)
+  text = text.replace(/^\d+\. (.*)$/gm, '<ol><li>$1</li></ol>');
+  text = text.replace(/<\/ol>\n<ol>/g, ''); // Fix consecutive <ol> tags
+
+  // Convert code blocks (e.g., `code`)
+  text = text.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+  // Convert line breaks to <br> tags
+  text = text.replace(/\n/g, '<br>');
+
+  return text;
+}
+
 function Message({
   message,
   color,
@@ -32,6 +64,9 @@ function Message({
 }: IMessage) {
   const isSystem = !message.author;
   const dateTime = message.date.toISOString().slice(0, 19).replace('T', ' ');
+
+  // Convert markdown message to HTML
+  const messageHtml = markdownToHtml(message.message);
 
   return (
     <S.Item
@@ -53,7 +88,8 @@ function Message({
             </Suspense>
           ) : (
             <Linkify componentDecorator={Link}>
-              <S.Message>{message.message}</S.Message>
+              {/* Render the HTML safely */}
+              <S.Message dangerouslySetInnerHTML={{ __html: messageHtml }} />
             </Linkify>
           )}
         </S.Wrapper>


### PR DESCRIPTION
Mark down added to convert markdown chat message text to HTML example, _Hi_ to <strong>Hi</strong>.
