### PR TITLE
Add search, media viewer, WhatsApp-style UX (v1.12.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vercel

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+PULL_REQUEST.md
 .env.local
 .env.development.local
 .env.test.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.12.0] - 2025-03-04
+
+### Added
+
+- **Search Messages** – Search by author or message text with highlighted matches; **Jump to date** calendar to view messages from a specific day (WhatsApp-style)
+- **Who are you?** – Prominent prompt to select your name so your messages appear on the right; choice is remembered in localStorage
+- **Media viewer** – Click images or videos to open in a full-screen lightbox; close with Escape or clicking outside
+- **Improved audio** – Audio attachments use `preload="metadata"` and a styled container; accessible labels
+- **Toast notifications** – Errors and file-load issues show in-app toasts instead of browser alerts
+- **Export visible messages** – Download the currently filtered message list as a `.txt` file
+- **Clear filters** – One-click reset to show all messages and clear search/date filters
+- **Scroll to top** – Floating button when scrolled down for long chats
+- **Virtual list** – Long chats use react-virtuoso for better performance (window scroll)
+- **Accessibility** – Skip-to-messages link, aria-labels on menu/overlay, focus trap in sidebar
+- **i18n** – Centralized UI strings in `src/i18n.ts` for easier editing and future localization
+- **Vercel** – `vercel.json` with `outputDirectory: build` for deployment
+
+### Changed
+
+- **Show all messages by default** – Removed the previous 1–100 message limit; full chat loads until you apply a filter
+- **Timestamp layout** – Date/time appears on its own line below the message bubble (WhatsApp-style), with full date and time
+- **Sidebar order** – “Who are you?” and “Search Messages” appear first; filter options and actions follow
+
+[1.12.0]: https://github.com/Meemkhaan/whatsapp-chat-parser-website/compare/1.11.1...1.12.0
+
 ## [1.11.1] - 2024-10-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,11 +4,21 @@
 
 This website allows you to upload a WhatsApp chat log and view its contents.
 You can upload a `txt` directly or a `zip` file containing the exported chat.  
-In case you export a `zip` file with the option `Attach Media`, you will be able to see images, videos and audio files directly in the website. Try it out by downloading the [example chat](https://github.com/Pustur/whatsapp-chat-parser-website/blob/master/src/assets/whatsapp-chat-parser-example.zip)!
+In case you export a `zip` file with the option **Attach Media**, you will be able to see images, videos and audio files directly in the website. Try it out by downloading the [example chat](https://github.com/Meemkhaan/whatsapp-chat-parser-website/blob/master/src/assets/whatsapp-chat-parser-example.zip)!
 
-The app runs locally and no logs are sent or stored anywhere.
+The app runs locally and **no logs are sent or stored anywhere**.
 
-The website is available at [whatsapp-chat-parser.netlify.app](https://whatsapp-chat-parser.netlify.app/)
+## Features
+
+- **Search Messages** – Search by author or text; **Jump to date** with a calendar to view a specific day (WhatsApp-style).
+- **Who are you?** – Select your name so your messages appear on the right; choice is remembered.
+- **Media viewer** – Click images or videos to open in a full-screen lightbox.
+- **Export** – Download the visible (filtered) messages as `.txt`.
+- **Filters** – Filter by message range or date; clear all with one click.
+- **Virtual list** – Smooth scrolling for long chats.
+- **Accessibility** – Skip link, keyboard support, focus trap in sidebar.
+
+The website is available at [whatsapp-chat-parser.netlify.app](https://whatsapp-chat-parser.netlify.app/). This fork can be deployed to [Vercel](https://vercel.com) using the included `vercel.json`.
 
 ## How to run locally
 
@@ -19,7 +29,7 @@ The website is available at [whatsapp-chat-parser.netlify.app](https://whatsapp-
 5. Run `npm run build` to build the compiled bundle that you'll find in the `build/` folder
 
 Any local server will do to run the built files.  
-It's also possible to download them directly from the [releases page](https://github.com/Pustur/whatsapp-chat-parser-website/releases).
+It's also possible to download them directly from the [releases page](https://github.com/Meemkhaan/whatsapp-chat-parser-website/releases).
 
 ## How to export WhatsApp chats
 
@@ -32,6 +42,7 @@ It's also possible to download them directly from the [releases page](https://gi
 - Libraries:
   - [React](https://reactjs.org/) (with [Jotai](https://jotai.org/))
   - [JSZip](https://stuk.github.io/jszip/)
+  - [react-virtuoso](https://virtuoso.dev/react-virtuoso/) (virtual list for long chats)
   - [whatsapp-chat-parser](https://github.com/Pustur/whatsapp-chat-parser)
 - CSS: [Styled Components](https://www.styled-components.com/)
 - Code formatting: [Prettier](https://prettier.io/)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The app runs locally and **no logs are sent or stored anywhere**.
 - **Virtual list** – Smooth scrolling for long chats.
 - **Accessibility** – Skip link, keyboard support, focus trap in sidebar.
 
-The website is available at [whatsapp-chat-parser.netlify.app](https://whatsapp-chat-parser.netlify.app/). This fork can be deployed to [Vercel](https://vercel.com) using the included `vercel.json`.
+**Live demo:** [Open app](https://whatsapp-chat-parser.vercel.app) · Original: [whatsapp-chat-parser.netlify.app](https://whatsapp-chat-parser.netlify.app/)
 
 ## How to run locally
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-linkify": "1.0.0-alpha",
+        "react-virtuoso": "^4.18.3",
         "styled-components": "6.1.13",
         "vite": "5.4.10",
         "whatsapp-chat-parser": "4.0.2"
@@ -4573,6 +4574,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.3.tgz",
+      "integrity": "sha512-fLz/peHAx4Eu0DLHurFEEI7Y6n5CqEoxBh04rgJM9yMuOJah2a9zWg/MUOmZLcp7zuWYorXq5+5bf3IRgkNvWg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -8494,6 +8505,12 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="
+    },
+    "react-virtuoso": {
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.3.tgz",
+      "integrity": "sha512-fLz/peHAx4Eu0DLHurFEEI7Y6n5CqEoxBh04rgJM9yMuOJah2a9zWg/MUOmZLcp7zuWYorXq5+5bf3IRgkNvWg==",
+      "requires": {}
     },
     "readable-stream": {
       "version": "2.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whatsapp-chat-parser-website",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "type": "module",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-linkify": "1.0.0-alpha",
+    "react-virtuoso": "^4.18.3",
     "styled-components": "6.1.13",
     "vite": "5.4.10",
     "whatsapp-chat-parser": "4.0.2"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,9 @@ import { rawFileAtom, messagesAtom } from './stores/global';
 import Dropzone from './components/Dropzone/Dropzone';
 import MessageViewer from './components/MessageViewer/MessageViewer';
 import Sidebar from './components/Sidebar/Sidebar';
+import ScrollToTop from './components/ScrollToTop/ScrollToTop';
 import * as S from './style';
+import { t } from './i18n';
 
 import exampleChat from './assets/whatsapp-chat-parser-example.zip';
 
@@ -47,19 +49,23 @@ function App() {
     };
   }, []);
 
+  const hasMessages = Array.isArray(messages) && messages.length > 0;
+
   return (
     <>
       <S.GlobalStyles />
+      <S.SkipLink href="#main-content">{t.skipToMessages}</S.SkipLink>
       <S.Container>
         <S.Header>
           <Dropzone onFileUpload={processFile} id="dropzone" />
-          <span>OR</span>
+          <span>{t.or}</span>
           <a href={exampleChat} download>
-            Download example chat
+            {t.downloadExample}
           </a>
         </S.Header>
         <MessageViewer />
-        {messages.length > 0 && <Sidebar />}
+        {hasMessages && <Sidebar />}
+        {hasMessages && <ScrollToTop />}
       </S.Container>
     </>
   );

--- a/src/components/ActiveUserSelector/ActiveUserSelector.tsx
+++ b/src/components/ActiveUserSelector/ActiveUserSelector.tsx
@@ -1,5 +1,6 @@
 import type { SetStateAction } from 'jotai';
 
+import { t } from '../../i18n';
 import * as S from '../Sidebar/style';
 
 interface IActiveUserSelector {
@@ -15,7 +16,7 @@ function ActiveUserSelector({
 }: IActiveUserSelector) {
   return (
     <S.Field>
-      <S.Label htmlFor="active-user">Active user</S.Label>
+      <S.Label htmlFor="active-user">{t.whoAreYou}</S.Label>
       <S.Select
         id="active-user"
         disabled={!participants.length}
@@ -23,13 +24,22 @@ function ActiveUserSelector({
         onChange={e => {
           setActiveUser(e.target.value);
         }}
+        title={t.whoAreYouTitle}
       >
+        <option value="" disabled>
+          {participants.length ? t.chooseYourName : t.loadChatFirst}
+        </option>
         {participants.map(participant => (
           <option key={participant} value={participant}>
             {participant}
           </option>
         ))}
       </S.Select>
+      {participants.length > 0 && (
+        <S.InputDescription style={{ marginTop: '0.25rem' }}>
+          {t.yourMessagesHint}
+        </S.InputDescription>
+      )}
     </S.Field>
   );
 }

--- a/src/components/Attachment/Attachment.tsx
+++ b/src/components/Attachment/Attachment.tsx
@@ -3,35 +3,10 @@ import { useAtomValue } from 'jotai';
 
 import { extractedFileAtom } from '../../stores/global';
 import { getMimeType } from '../../utils/utils';
+import { t } from '../../i18n';
+import MediaViewer from '../MediaViewer/MediaViewer';
 
 import * as S from './style';
-
-const renderAttachment = (
-  fileName: string,
-  mimeType: string,
-  attachment: string,
-) => {
-  const src = `data:${mimeType};base64,${attachment}`;
-
-  if (mimeType.startsWith('image/')) {
-    return <img src={src} title={fileName} alt="" />;
-  }
-  if (mimeType.startsWith('video/')) {
-    return (
-      <video controls title={fileName}>
-        <source src={src} type={mimeType} />
-      </video>
-    );
-  }
-  if (mimeType.startsWith('audio/')) {
-    return <audio controls src={src} title={fileName} />;
-  }
-  return (
-    <a href={attachment} download={fileName}>
-      {fileName}
-    </a>
-  );
-};
 
 interface IAttachment {
   fileName: string;
@@ -42,6 +17,7 @@ function Attachment({ fileName }: IAttachment) {
   const [attachment, setAttachment] = useState<null | string>(null);
   const [error, setError] = useState<null | Error>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [viewerOpen, setViewerOpen] = useState(false);
   const mimeType = getMimeType(fileName) || '';
 
   const loadAttachment = useCallback(() => {
@@ -67,7 +43,6 @@ function Attachment({ fileName }: IAttachment) {
     // eslint-disable-next-line no-underscore-dangle
     const uncompressedSize = file?._data?.uncompressedSize ?? -1;
 
-    // We actually need to check > 0 because big files have negative numbers (int overflow? kek)
     if (uncompressedSize > 0 && uncompressedSize < sizeLimit) {
       setIsLoading(true);
       file.async('blob').then(blob => {
@@ -90,18 +65,98 @@ function Attachment({ fileName }: IAttachment) {
     }
   }, [loadAttachment, mimeType]);
 
-  if (error) return <div>{error.toString()}</div>;
-  if (attachment) return renderAttachment(fileName, mimeType, attachment);
+  if (error) return <S.Error>{error.message}</S.Error>;
+  if (!attachment) {
+    return (
+      <div>
+        {isLoading ? (
+          <S.Loading>{t.loadingAttachment(fileName)}</S.Loading>
+        ) : (
+          <S.Button type="button" onClick={loadAttachment}>
+            Load {fileName}
+          </S.Button>
+        )}
+      </div>
+    );
+  }
+
+  const dataSrc =
+    attachment.startsWith('data:') || attachment.startsWith('blob:')
+      ? attachment
+      : `data:${mimeType};base64,${attachment}`;
+
+  if (mimeType.startsWith('image/')) {
+    return (
+      <>
+        <S.MediaThumb
+          role="button"
+          tabIndex={0}
+          onClick={() => setViewerOpen(true)}
+          onKeyDown={e => e.key === 'Enter' && setViewerOpen(true)}
+          aria-label={t.chatImage}
+        >
+          <img
+            src={dataSrc}
+            title={fileName}
+            alt={fileName || t.chatImage}
+          />
+        </S.MediaThumb>
+        <MediaViewer
+          open={viewerOpen}
+          onClose={() => setViewerOpen(false)}
+          type="image"
+          src={dataSrc}
+          title={fileName}
+        />
+      </>
+    );
+  }
+
+  if (mimeType.startsWith('video/')) {
+    return (
+      <>
+        <S.MediaThumb
+          role="button"
+          tabIndex={0}
+          onClick={() => setViewerOpen(true)}
+          onKeyDown={e => e.key === 'Enter' && setViewerOpen(true)}
+          aria-label={t.chatVideo}
+        >
+          <video title={fileName} preload="metadata">
+            <source src={dataSrc} type={mimeType} />
+          </video>
+          <S.PlayOverlay aria-hidden>▶</S.PlayOverlay>
+        </S.MediaThumb>
+        <MediaViewer
+          open={viewerOpen}
+          onClose={() => setViewerOpen(false)}
+          type="video"
+          src={dataSrc}
+          title={fileName}
+          mimeType={mimeType}
+        />
+      </>
+    );
+  }
+
+  if (mimeType.startsWith('audio/')) {
+    return (
+      <S.AudioWrap>
+        <audio
+          controls
+          src={dataSrc}
+          title={fileName}
+          preload="metadata"
+          aria-label={fileName || t.chatAudio}
+        />
+      </S.AudioWrap>
+    );
+  }
+
   return (
-    <div>
-      {isLoading ? (
-        <div>Loading {fileName}...</div>
-      ) : (
-        <S.Button type="button" onClick={loadAttachment}>
-          Load {fileName}
-        </S.Button>
-      )}
-    </div>
+    <a href={attachment} download={fileName}>
+      {fileName}
+    </a>
   );
 }
 

--- a/src/components/Attachment/style.ts
+++ b/src/components/Attachment/style.ts
@@ -7,4 +7,61 @@ const Button = styled.button`
   ${standardButton}
 `;
 
-export { Button };
+const Error = styled.div`
+  font-size: 0.9rem;
+  color: #c00;
+
+  @media (prefers-color-scheme: dark) {
+    color: #f66;
+  }
+`;
+
+const Loading = styled.div`
+  font-size: 0.9rem;
+  opacity: 0.8;
+`;
+
+const PlayOverlay = styled.span`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+  color: white;
+  font-size: 3rem;
+  pointer-events: none;
+`;
+
+const MediaThumb = styled.div`
+  cursor: pointer;
+  display: inline-block;
+  max-width: 100%;
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+
+  img,
+  video {
+    max-width: 100%;
+    max-height: 70vh;
+    display: block;
+    vertical-align: middle;
+  }
+
+  video {
+    max-height: 200px;
+  }
+`;
+
+const AudioWrap = styled.div`
+  min-width: 240px;
+  max-width: 100%;
+
+  audio {
+    width: 100%;
+    height: 32px;
+  }
+`;
+
+export { Button, Error, Loading, MediaThumb, PlayOverlay, AudioWrap };

--- a/src/components/Credits/Credits.tsx
+++ b/src/components/Credits/Credits.tsx
@@ -1,12 +1,14 @@
+import { t } from '../../i18n';
+
 function Credits() {
   return (
     <div>
       <small>
-        Made by <a href="https://lorisbettazza.com">Loris Bettazza</a>
+        {t.madeBy}{' '}
+        <a href="https://lorisbettazza.com">Loris Bettazza</a>
         <br />
-        View{' '}
         <a href="https://github.com/Pustur/whatsapp-chat-parser-website">
-          Source code
+          {t.sourceCode}
         </a>
       </small>
     </div>

--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 
+import { t } from '../../i18n';
 import * as S from './style';
 
 const preventDefaults = (e: React.DragEvent<HTMLFormElement>) => {
@@ -61,9 +62,8 @@ function Dropzone({ id, onFileUpload }: IDropzone) {
       />
       <S.Label htmlFor={id} $isHighlighted={isHighlighted}>
         <S.P>
-          Click here to upload a file or drag and drop it onto the dashed region
-          (supported formats: <S.Extension>txt</S.Extension>,{' '}
-          <S.Extension>zip</S.Extension>)
+          {t.dropzoneLabel} ({t.dropzoneFormats}{' '}
+          <S.Extension>{t.txt}</S.Extension>, <S.Extension>{t.zip}</S.Extension>)
         </S.P>
       </S.Label>
     </form>

--- a/src/components/FilterMessageDatesForm/FilterMessageDatesForm.tsx
+++ b/src/components/FilterMessageDatesForm/FilterMessageDatesForm.tsx
@@ -1,4 +1,5 @@
 import { DateBounds } from '../../types';
+import { t } from '../../i18n';
 import { getISODateString } from '../../utils/utils';
 
 import * as S from '../Sidebar/style';
@@ -15,9 +16,9 @@ function FilterMessageDatesForm({
   return (
     <S.Form onSubmit={setMessagesByDate}>
       <S.Fieldset>
-        <legend>Messages date window</legend>
+        <legend>{t.messagesDateWindow}</legend>
         <S.Field>
-          <S.Label htmlFor="start-date">Start</S.Label>
+          <S.Label htmlFor="start-date">{t.start}</S.Label>
           <S.Input
             id="start-date"
             name="startDate"
@@ -28,7 +29,7 @@ function FilterMessageDatesForm({
           />
         </S.Field>
         <S.Field>
-          <S.Label htmlFor="end-date">End</S.Label>
+          <S.Label htmlFor="end-date">{t.end}</S.Label>
           <S.Input
             id="end-date"
             name="endDate"
@@ -39,11 +40,8 @@ function FilterMessageDatesForm({
           />
         </S.Field>
         <S.Field>
-          <S.Submit type="submit" value="Apply" />
-          <S.InputDescription>
-            A high delta may freeze the page for a while, change this with
-            caution
-          </S.InputDescription>
+          <S.Submit type="submit" value={t.apply} />
+          <S.InputDescription>{t.dateRangeCaution}</S.InputDescription>
         </S.Field>
       </S.Fieldset>
     </S.Form>

--- a/src/components/FilterMessageLimitsForm/FilterMessageLimitsForm.tsx
+++ b/src/components/FilterMessageLimitsForm/FilterMessageLimitsForm.tsx
@@ -1,3 +1,4 @@
+import { t } from '../../i18n';
 import * as S from '../Sidebar/style';
 
 import { ILimits } from '../../types';
@@ -14,9 +15,9 @@ function FilterMessageLimitsForm({
   return (
     <S.Form onSubmit={setMessageLimits}>
       <S.Fieldset>
-        <legend>Messages limit</legend>
+        <legend>{t.messagesLimit}</legend>
         <S.Field>
-          <S.Label htmlFor="lower-limit">Start</S.Label>
+          <S.Label htmlFor="lower-limit">{t.start}</S.Label>
           <S.Input
             id="lower-limit"
             name="lowerLimit"
@@ -26,7 +27,7 @@ function FilterMessageLimitsForm({
           />
         </S.Field>
         <S.Field>
-          <S.Label htmlFor="upper-limit">End</S.Label>
+          <S.Label htmlFor="upper-limit">{t.end}</S.Label>
           <S.Input
             id="upper-limit"
             name="upperLimit"
@@ -36,11 +37,8 @@ function FilterMessageLimitsForm({
           />
         </S.Field>
         <S.Field>
-          <S.Submit type="submit" value="Apply" />
-          <S.InputDescription>
-            A high delta may freeze the page for a while, change this with
-            caution
-          </S.InputDescription>
+          <S.Submit type="submit" value={t.apply} />
+          <S.InputDescription>{t.messagesLimitCaution}</S.InputDescription>
         </S.Field>
       </S.Fieldset>
     </S.Form>

--- a/src/components/FilterModeSelector/FilterModeSelector.tsx
+++ b/src/components/FilterModeSelector/FilterModeSelector.tsx
@@ -1,5 +1,5 @@
 import { FilterMode } from '../../types';
-import { capitalize } from '../../utils/utils';
+import { t } from '../../i18n';
 import * as S from '../Sidebar/style';
 
 interface IFilterModeSelector {
@@ -13,8 +13,8 @@ function FilterModeSelector({
 }: IFilterModeSelector) {
   return (
     <S.Fieldset>
-      <legend>Filter by</legend>
-      {['index', 'date'].map(name => (
+      <legend>{t.filterBy}</legend>
+      {(['index', 'date'] as const).map(name => (
         <S.RadioField key={name}>
           <input
             id={name}
@@ -23,7 +23,7 @@ function FilterModeSelector({
             checked={filterMode === name}
             onChange={e => setFilterMode(e.target.value as FilterMode)}
           />
-          <S.Label htmlFor={name}>{capitalize(name)}</S.Label>
+          <S.Label htmlFor={name}>{t[name]}</S.Label>
         </S.RadioField>
       ))}
     </S.Fieldset>

--- a/src/components/MediaViewer/MediaViewer.tsx
+++ b/src/components/MediaViewer/MediaViewer.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import { zIndex } from '../../utils/z-index';
+import { t } from '../../i18n';
+
+const Overlay = styled.div<{ $open: boolean }>`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.9);
+  z-index: ${zIndex.mediaViewer};
+  display: ${p => (p.$open ? 'flex' : 'none')};
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+`;
+
+const Content = styled.div`
+  max-width: 95vw;
+  max-height: 95vh;
+  cursor: default;
+
+  img,
+  video {
+    max-width: 95vw;
+    max-height: 95vh;
+    object-fit: contain;
+  }
+
+  video {
+    background: #000;
+  }
+`;
+
+const CloseHint = styled.p`
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.7);
+`;
+
+interface IMediaViewer {
+  open: boolean;
+  onClose: () => void;
+  type: 'image' | 'video';
+  src: string;
+  title?: string;
+  mimeType?: string;
+}
+
+function MediaViewer({ open, onClose, type, src, title, mimeType }: IMediaViewer) {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [open, onClose]);
+
+  const stopPropagation = (e: React.MouseEvent) => e.stopPropagation();
+
+  if (!open) return null;
+
+  return (
+    <Overlay
+      $open={open}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={t.closeMediaViewer}
+    >
+      <Content ref={contentRef} onClick={stopPropagation}>
+        {type === 'image' && (
+          <img
+            src={src}
+            alt={title || t.chatImage}
+            title={title}
+          />
+        )}
+        {type === 'video' && (
+          <video controls autoPlay title={title || t.chatVideo}>
+            <source src={src} type={mimeType || 'video/mp4'} />
+          </video>
+        )}
+      </Content>
+      <CloseHint>{t.closeMediaViewer}</CloseHint>
+    </Overlay>
+  );
+}
+
+export default MediaViewer;

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import React, { Suspense } from 'react';
 import Linkify from 'react-linkify';
 
 import Attachment from '../Attachment/Attachment';
@@ -6,6 +6,7 @@ import Poll from '../Poll/Poll';
 import * as S from './style';
 import { IndexedMessage } from '../../types';
 import { parsePollMessage } from '../../utils/poll-parser';
+import { t } from '../../i18n';
 
 function Link(
   decoratedHref: string,
@@ -19,11 +20,25 @@ function Link(
   );
 }
 
+function highlightMatches(text: string, query: string): React.ReactNode {
+  if (!query.trim()) return text;
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const parts = text.split(new RegExp(`(${escaped})`, 'gi'));
+  return parts.map((part, i) =>
+    part.toLowerCase() === query.trim().toLowerCase() ? (
+      <mark key={i}>{part}</mark>
+    ) : (
+      part
+    ),
+  );
+}
+
 interface IMessage {
   message: IndexedMessage;
   color: string;
   isActiveUser: boolean;
   sameAuthorAsPrevious: boolean;
+  searchQuery?: string;
 }
 
 function Message({
@@ -31,19 +46,24 @@ function Message({
   color,
   isActiveUser,
   sameAuthorAsPrevious,
+  searchQuery,
 }: IMessage) {
   const isSystem = !message.author;
   const dateTime = message.date.toISOString().slice(0, 19).replace('T', ' ');
   const pollData = parsePollMessage(message.message);
+  const textContent =
+    searchQuery && !message.attachment && pollData === null
+      ? highlightMatches(message.message, searchQuery)
+      : message.message;
   let messageComponent = (
     <Linkify componentDecorator={Link}>
-      <S.Message>{message.message}</S.Message>
+      <S.Message>{textContent}</S.Message>
     </Linkify>
   );
 
   if (message.attachment) {
     messageComponent = (
-      <Suspense fallback={`Loading ${message.attachment.fileName}...`}>
+      <Suspense fallback={t.loadingAttachment(message.attachment.fileName)}>
         <Attachment fileName={message.attachment.fileName} />
       </Suspense>
     );
@@ -68,15 +88,17 @@ function Message({
           {messageComponent}
         </S.Wrapper>
         {!isSystem && (
-          <S.Date dateTime={dateTime}>
-            {new Intl.DateTimeFormat('default', {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-              hour: 'numeric',
-              minute: 'numeric',
-            }).format(message.date)}
-          </S.Date>
+          <S.DateRow>
+            <S.Date dateTime={dateTime}>
+              {new Intl.DateTimeFormat('default', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+              }).format(message.date)}
+            </S.Date>
+          </S.DateRow>
         )}
       </S.Bubble>
     </S.Item>

--- a/src/components/Message/style.ts
+++ b/src/components/Message/style.ts
@@ -84,8 +84,12 @@ const Index = styled.div<{ $isSystem: boolean; $isActiveUser: boolean }>`
 const Bubble = styled.div<{ $isSystem: boolean; $isActiveUser: boolean }>`
   ${messageBaseStyle}
 
+  display: inline-flex;
+  flex-direction: column;
+  align-items: stretch;
   position: relative;
   background-color: white;
+  max-width: 65%;
   ${props =>
     props.$isSystem &&
     css`
@@ -99,7 +103,7 @@ const Bubble = styled.div<{ $isSystem: boolean; $isActiveUser: boolean }>`
     `}
 
   @media (max-width: 699px) {
-    flex-direction: column;
+    max-width: 85%;
   }
 
   @media (min-width: 700px) {
@@ -144,19 +148,32 @@ const Message = styled.div`
   ${overflowBreakWord}
 
   white-space: pre-wrap;
-`;
 
-const Date = styled.time`
-  flex: 0 0 auto;
-  align-self: flex-end;
-  margin-left: 1rem;
-  white-space: nowrap;
-  font-size: 75%;
-  opacity: 0.6;
+  mark {
+    background: rgba(255, 235, 59, 0.6);
+    border-radius: 2px;
+    padding: 0 2px;
+  }
 
-  @media (max-width: 699px) {
-    margin-top: 0.25rem;
+  @media (prefers-color-scheme: dark) {
+    mark {
+      background: rgba(255, 193, 7, 0.5);
+    }
   }
 `;
 
-export { Item, Bubble, Index, Wrapper, Author, Message, Date };
+const DateRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.15rem;
+  min-height: 1em;
+`;
+
+const Date = styled.time`
+  white-space: nowrap;
+  font-size: 11px;
+  opacity: 0.7;
+  align-self: flex-end;
+`;
+
+export { Item, Bubble, Index, Wrapper, Author, Message, DateRow, Date };

--- a/src/components/MessageViewer/MessageViewer.tsx
+++ b/src/components/MessageViewer/MessageViewer.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo, useEffect, useCallback } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
-import { Virtuoso } from 'react-virtuoso';
+import React, { useMemo, useEffect, useCallback, useRef } from 'react';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 
 import Message from '../Message/Message';
+import SearchResultsPanel from '../SearchResultsPanel/SearchResultsPanel';
 import * as S from './style';
 import { t } from '../../i18n';
 import {
@@ -17,6 +18,7 @@ import {
   globalFilterModeAtom,
   limitsAtom,
   searchQueryAtom,
+  scrollToMessageIndexAtom,
 } from '../../stores/filters';
 import {
   filterMessagesByDate,
@@ -31,6 +33,10 @@ function MessageViewer() {
   const messages = useAtomValue(messagesAtom);
   const filterMode = useAtomValue(globalFilterModeAtom);
   const searchQuery = useAtomValue(searchQueryAtom);
+  const scrollToMessageIndex = useAtomValue(scrollToMessageIndexAtom);
+  const setScrollToMessageIndex = useSetAtom(scrollToMessageIndexAtom);
+  const setSearchQuery = useSetAtom(searchQueryAtom);
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
   const { start: startDate, end: endDate } = useAtomValue(datesAtom);
   const endDatePlusOne = new Date(endDate);
   endDatePlusOne.setDate(endDatePlusOne.getDate() + 1);
@@ -98,8 +104,47 @@ function MessageViewer() {
     }
   }, [activeUser, participants]);
 
+  // When user clicks a search result: scroll to that message in the full conversation
+  useEffect(() => {
+    if (scrollToMessageIndex == null) return;
+    const position = rangeFiltered.findIndex(
+      (m) => m.index === scrollToMessageIndex,
+    );
+    if (position < 0) {
+      setScrollToMessageIndex(null);
+      return;
+    }
+    const id = requestAnimationFrame(() => {
+      virtuosoRef.current?.scrollToIndex({
+        index: position,
+        behavior: 'smooth',
+      });
+      setScrollToMessageIndex(null);
+    });
+    return () => cancelAnimationFrame(id);
+  }, [
+    scrollToMessageIndex,
+    rangeFiltered,
+    setScrollToMessageIndex,
+  ]);
+
+  const handleSearchResultSelect = useCallback(
+    (message: { index: number }) => {
+      setScrollToMessageIndex(message.index);
+      setSearchQuery('');
+    },
+    [setScrollToMessageIndex, setSearchQuery],
+  );
+
   return (
     <S.Container id="main-content" tabIndex={-1}>
+      {messages.length > 0 && isSearchActive && (
+        <SearchResultsPanel
+          results={renderedMessages}
+          query={searchQuery}
+          onSelectMessage={handleSearchResultSelect}
+        />
+      )}
       {messages.length > 0 && (
         <S.P>
           <S.Info>
@@ -130,6 +175,7 @@ function MessageViewer() {
 
       <S.List as="div">
         <Virtuoso
+          ref={virtuosoRef}
           useWindowScroll
           totalCount={renderedMessages.length}
           itemContent={itemContent}

--- a/src/components/MessageViewer/MessageViewer.tsx
+++ b/src/components/MessageViewer/MessageViewer.tsx
@@ -1,8 +1,10 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect, useCallback } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
+import { Virtuoso } from 'react-virtuoso';
 
 import Message from '../Message/Message';
 import * as S from './style';
+import { t } from '../../i18n';
 import {
   activeUserAtom,
   messagesAtom,
@@ -14,8 +16,13 @@ import {
   datesAtom,
   globalFilterModeAtom,
   limitsAtom,
+  searchQueryAtom,
 } from '../../stores/filters';
-import { filterMessagesByDate, getISODateString } from '../../utils/utils';
+import {
+  filterMessagesByDate,
+  filterMessagesBySearch,
+  getISODateString,
+} from '../../utils/utils';
 
 function MessageViewer() {
   const limits = useAtomValue(limitsAtom);
@@ -23,6 +30,7 @@ function MessageViewer() {
   const participants = useAtomValue(participantsAtom);
   const messages = useAtomValue(messagesAtom);
   const filterMode = useAtomValue(globalFilterModeAtom);
+  const searchQuery = useAtomValue(searchQueryAtom);
   const { start: startDate, end: endDate } = useAtomValue(datesAtom);
   const endDatePlusOne = new Date(endDate);
   endDatePlusOne.setDate(endDatePlusOne.getDate() + 1);
@@ -38,56 +46,94 @@ function MessageViewer() {
     [participants],
   );
 
-  const renderedMessages =
+  const rangeFiltered =
     filterMode === 'index'
       ? messages.slice(limits.low - 1, limits.high)
       : filterMessagesByDate(messages, startDate, endDatePlusOne);
 
-  const isLimited = renderedMessages.length !== messages.length;
+  const renderedMessages = filterMessagesBySearch(rangeFiltered, searchQuery);
+  const isLimited = rangeFiltered.length !== messages.length;
+  const isSearchActive = searchQuery.trim().length > 0;
 
+  const itemContent = useCallback(
+    (index: number) => {
+      const message = renderedMessages[index];
+      const prevMessage = renderedMessages[index - 1];
+      return (
+        <Message
+          key={message.index}
+          message={message}
+          color={colorMap[message.author || '']}
+          isActiveUser={activeUser === message.author}
+          sameAuthorAsPrevious={
+            !!prevMessage && prevMessage.author === message.author
+          }
+          searchQuery={isSearchActive ? searchQuery : undefined}
+        />
+      );
+    },
+    [
+      renderedMessages,
+      colorMap,
+      activeUser,
+      isSearchActive,
+      searchQuery,
+    ],
+  );
+
+  // Restore or set "who I am" (persist to localStorage)
   useEffect(() => {
-    setActiveUser(participants[0] || '');
+    if (!participants.length) return;
+    const stored = localStorage.getItem('chatViewerActiveUser');
+    if (stored && participants.includes(stored)) {
+      setActiveUser(stored);
+    } else {
+      setActiveUser(participants[0] || '');
+    }
   }, [setActiveUser, participants]);
 
+  useEffect(() => {
+    if (activeUser && participants.includes(activeUser)) {
+      localStorage.setItem('chatViewerActiveUser', activeUser);
+    }
+  }, [activeUser, participants]);
+
   return (
-    <S.Container>
+    <S.Container id="main-content" tabIndex={-1}>
       {messages.length > 0 && (
         <S.P>
           <S.Info>
-            {isLimited && filterMode === 'index' && (
+            {isSearchActive && (
+              <span>
+                {renderedMessages.length} messages matching "{searchQuery}"
+              </span>
+            )}
+            {!isSearchActive && isLimited && filterMode === 'index' && (
               <span>
                 Showing messages {limits.low} to{' '}
                 {Math.min(limits.high, messages.length)} (
-                {renderedMessages.length} out of {messages.length})
+                {rangeFiltered.length} out of {messages.length})
               </span>
             )}
-            {isLimited && filterMode === 'date' && (
+            {!isSearchActive && isLimited && filterMode === 'date' && (
               <span>
                 Showing messages from {getISODateString(startDate)} to{' '}
                 {getISODateString(endDate)}
               </span>
             )}
-            {!isLimited && <span>Showing all {messages.length} messages</span>}
+            {!isSearchActive && !isLimited && (
+              <span>{t.showingAll(messages.length)}</span>
+            )}
           </S.Info>
         </S.P>
       )}
 
-      <S.List>
-        {renderedMessages.map((message, i, arr) => {
-          const prevMessage = arr[i - 1];
-
-          return (
-            <Message
-              key={message.index}
-              message={message}
-              color={colorMap[message.author || '']}
-              isActiveUser={activeUser === message.author}
-              sameAuthorAsPrevious={
-                prevMessage && prevMessage.author === message.author
-              }
-            />
-          );
-        })}
+      <S.List as="div">
+        <Virtuoso
+          useWindowScroll
+          totalCount={renderedMessages.length}
+          itemContent={itemContent}
+        />
       </S.List>
     </S.Container>
   );

--- a/src/components/ScrollToTop/ScrollToTop.tsx
+++ b/src/components/ScrollToTop/ScrollToTop.tsx
@@ -1,0 +1,63 @@
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { whatsappThemeColor } from '../../utils/colors';
+import { t } from '../../i18n';
+
+const Button = styled.button`
+  position: fixed;
+  right: 1rem;
+  bottom: 5rem;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: ${whatsappThemeColor};
+  color: white;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  opacity: 0.9;
+  transition: opacity 0.2s, transform 0.2s;
+  z-index: 50;
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    opacity: 1;
+    transform: scale(1.05);
+  }
+
+  @media (min-width: 700px) {
+    right: 2rem;
+    bottom: 6rem;
+  }
+`;
+
+const SCROLL_THRESHOLD = 400;
+
+function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > SCROLL_THRESHOLD);
+    window.addEventListener('scroll', onScroll);
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <Button
+      type="button"
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      aria-label={t.scrollToTop}
+      title={t.scrollToTop}
+    >
+      ↑
+    </Button>
+  );
+}
+
+export default ScrollToTop;

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -1,0 +1,24 @@
+import { useAtom } from 'jotai';
+import { searchQueryAtom } from '../../stores/filters';
+import { t } from '../../i18n';
+import * as S from '../Sidebar/style';
+
+function SearchInput() {
+  const [query, setQuery] = useAtom(searchQueryAtom);
+
+  return (
+    <S.Field>
+      <S.Label htmlFor="search-messages">{t.searchLabel}</S.Label>
+      <S.Input
+        id="search-messages"
+        type="search"
+        placeholder={t.searchPlaceholder}
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        aria-label={t.searchPlaceholder}
+      />
+    </S.Field>
+  );
+}
+
+export default SearchInput;

--- a/src/components/SearchMessagesSection/SearchMessagesSection.tsx
+++ b/src/components/SearchMessagesSection/SearchMessagesSection.tsx
@@ -1,0 +1,77 @@
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import {
+  searchQueryAtom,
+  datesAtom,
+  globalFilterModeAtom,
+} from '../../stores/filters';
+import { messagesDateBoundsAtom } from '../../stores/global';
+import { getISODateString } from '../../utils/utils';
+import { t } from '../../i18n';
+import * as S from '../Sidebar/style';
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0);
+}
+
+function endOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+}
+
+function SearchMessagesSection() {
+  const [searchQuery, setSearchQuery] = useAtom(searchQueryAtom);
+  const [dates, setDates] = useAtom(datesAtom);
+  const setGlobalFilterMode = useSetAtom(globalFilterModeAtom);
+  const messagesDateBounds = useAtomValue(messagesDateBoundsAtom);
+
+  const minDate = getISODateString(messagesDateBounds.start);
+  const maxDate = getISODateString(messagesDateBounds.end);
+  const isSingleDay =
+    getISODateString(dates.start) === getISODateString(dates.end);
+  const selectedDateValue = isSingleDay
+    ? getISODateString(dates.start)
+    : '';
+
+  const handleJumpToDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (!value) return;
+    const d = new Date(value + 'T12:00:00');
+    if (Number.isNaN(d.getTime())) return;
+    setDates({
+      start: startOfDay(d),
+      end: endOfDay(d),
+    });
+    setGlobalFilterMode('date');
+  };
+
+  return (
+    <S.Fieldset>
+      <legend>{t.searchMessagesTitle}</legend>
+      <S.Field>
+        <S.Label htmlFor="search-messages">{t.searchLabel}</S.Label>
+        <S.Input
+          id="search-messages"
+          type="search"
+          placeholder={t.searchPlaceholder}
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          aria-label={t.searchPlaceholder}
+        />
+      </S.Field>
+      <S.Field>
+        <S.Label htmlFor="jump-to-date">{t.jumpToDate}</S.Label>
+        <S.Input
+          id="jump-to-date"
+          type="date"
+          min={minDate}
+          max={maxDate}
+          value={selectedDateValue}
+          onChange={handleJumpToDate}
+          aria-label={t.jumpToDate}
+          title={t.pickDatePlaceholder}
+        />
+      </S.Field>
+    </S.Fieldset>
+  );
+}
+
+export default SearchMessagesSection;

--- a/src/components/SearchResultsPanel/SearchResultsPanel.tsx
+++ b/src/components/SearchResultsPanel/SearchResultsPanel.tsx
@@ -1,0 +1,132 @@
+import styled from 'styled-components';
+import { t } from '../../i18n';
+import type { IndexedMessage } from '../../types';
+
+const Panel = styled.section`
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 8px;
+
+  @media (prefers-color-scheme: dark) {
+    background: rgba(255, 255, 255, 0.06);
+  }
+`;
+
+const Title = styled.h2`
+  margin: 0 0 0.5rem 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+`;
+
+const List = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 280px;
+  overflow-y: auto;
+`;
+
+const ResultItem = styled.button`
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0.5rem 0.5rem 0.5rem 0;
+  text-align: left;
+  background: none;
+  border: none;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.06);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    border-color: rgba(255, 255, 255, 0.1);
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+  }
+`;
+
+const ResultAuthor = styled.span`
+  font-weight: 600;
+  font-size: 0.8rem;
+  display: block;
+  margin-bottom: 0.15rem;
+`;
+
+const ResultSnippet = styled.span`
+  font-size: 0.85rem;
+  opacity: 0.9;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+
+const ResultDate = styled.span`
+  font-size: 0.75rem;
+  opacity: 0.7;
+  display: block;
+  margin-top: 0.2rem;
+`;
+
+const SNIPPET_LENGTH = 80;
+
+function snippet(text: string, maxLen: number): string {
+  const t = text.replace(/\s+/g, ' ').trim();
+  if (t.length <= maxLen) return t;
+  return t.slice(0, maxLen) + '…';
+}
+
+interface SearchResultsPanelProps {
+  results: IndexedMessage[];
+  query: string;
+  onSelectMessage: (message: IndexedMessage) => void;
+}
+
+function SearchResultsPanel({
+  results,
+  query,
+  onSelectMessage,
+}: SearchResultsPanelProps) {
+  if (!results.length) return null;
+
+  return (
+    <Panel aria-label={t.searchResults}>
+      <Title>
+        {t.showingSearch(results.length, query)}
+      </Title>
+      <List>
+        {results.map((message) => (
+          <ResultItem
+            key={message.index}
+            type="button"
+            onClick={() => onSelectMessage(message)}
+            title={t.clickToShowInChat}
+          >
+            <ResultAuthor>{message.author || 'System'}</ResultAuthor>
+            <ResultSnippet>{snippet(message.message, SNIPPET_LENGTH)}</ResultSnippet>
+            <ResultDate>
+              {new Intl.DateTimeFormat('default', {
+                dateStyle: 'short',
+                timeStyle: 'short',
+              }).format(message.date)}
+            </ResultDate>
+          </ResultItem>
+        ))}
+      </List>
+    </Panel>
+  );
+}
+
+export default SearchResultsPanel;

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState, startTransition } from 'react';
+import { useRef, useEffect, useState, useCallback, startTransition } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 
 import Credits from '../Credits/Credits';
@@ -6,8 +6,10 @@ import FilterModeSelector from '../FilterModeSelector/FilterModeSelector';
 import FilterMessageLimitsForm from '../FilterMessageLimitsForm/FilterMessageLimitsForm';
 import FilterMessageDatesForm from '../FilterMessageDatesForm/FilterMessageDatesForm';
 import ActiveUserSelector from '../ActiveUserSelector/ActiveUserSelector';
+import SearchMessagesSection from '../SearchMessagesSection/SearchMessagesSection';
 
 import * as S from './style';
+import { t } from '../../i18n';
 import {
   activeUserAtom,
   isAnonymousAtom,
@@ -19,8 +21,15 @@ import {
   datesAtom,
   globalFilterModeAtom,
   limitsAtom,
+  searchQueryAtom,
 } from '../../stores/filters';
 import { FilterMode } from '../../types';
+import {
+  filterMessagesByDate,
+  filterMessagesBySearch,
+} from '../../utils/utils';
+import type { IndexedMessage } from '../../types';
+import { messagesAtom } from '../../stores/global';
 
 function Sidebar() {
   const [isMenuOpen, setIsMenuOpen] = useAtom(isMenuOpenAtom);
@@ -32,9 +41,53 @@ function Sidebar() {
   const messagesDateBounds = useAtomValue(messagesDateBoundsAtom);
   const participants = useAtomValue(participantsAtom);
   const [activeUser, setActiveUser] = useAtom(activeUserAtom);
+  const setSearchQuery = useSetAtom(searchQueryAtom);
+  const searchQuery = useAtomValue(searchQueryAtom);
+  const appliedFilterMode = useAtomValue(globalFilterModeAtom);
+  const appliedDates = useAtomValue(datesAtom);
+  const messages = useAtomValue(messagesAtom) as IndexedMessage[];
 
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const openButtonRef = useRef<HTMLButtonElement>(null);
+  const sidebarRef = useRef<HTMLElement>(null);
+  const exportListRef = useRef<IndexedMessage[]>([]);
+
+  const endDatePlusOne = new Date(appliedDates.end);
+  endDatePlusOne.setDate(endDatePlusOne.getDate() + 1);
+  const rangeFiltered =
+    appliedFilterMode === 'index'
+      ? messages.slice(limits.low - 1, limits.high)
+      : filterMessagesByDate(messages, appliedDates.start, endDatePlusOne);
+  const toExport = filterMessagesBySearch(rangeFiltered, searchQuery);
+  exportListRef.current = toExport;
+
+  const handleClearFilters = useCallback(() => {
+    setLimits({ low: 1, high: 999_999 });
+    setGlobalFilterMode('index');
+    setDates(messagesDateBounds);
+    setSearchQuery('');
+  }, [
+    setLimits,
+    setGlobalFilterMode,
+    setDates,
+    messagesDateBounds,
+    setSearchQuery,
+  ]);
+
+  const handleExportVisible = useCallback(() => {
+    const list = exportListRef.current;
+    const text = list
+      .map(
+        m => `[${m.date.toISOString()}] ${m.author || 'System'}: ${m.message}`,
+      )
+      .join('\n');
+    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `chat-export-${new Date().toISOString().slice(0, 10)}.txt`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  }, []);
 
   const setMessageLimits = (e: React.FormEvent<HTMLFormElement>) => {
     const entries = Object.fromEntries(new FormData(e.currentTarget));
@@ -70,6 +123,31 @@ function Sidebar() {
     else openButtonRef.current?.focus();
   }, [isMenuOpen]);
 
+  // Focus trap when sidebar is open
+  useEffect(() => {
+    if (!isMenuOpen || !sidebarRef.current) return;
+    const el = sidebarRef.current;
+    const focusables = el.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first?.focus();
+      }
+    };
+    el.addEventListener('keydown', onKeyDown);
+    return () => el.removeEventListener('keydown', onKeyDown);
+  }, [isMenuOpen]);
+
   return (
     <>
       <S.MenuOpenButton
@@ -77,25 +155,35 @@ function Sidebar() {
         type="button"
         onClick={() => setIsMenuOpen(true)}
         ref={openButtonRef}
+        aria-label={t.openMenu}
+        aria-expanded={isMenuOpen}
       >
-        Open menu
+        {t.openMenu}
       </S.MenuOpenButton>
       <S.Overlay
         type="button"
         $isActive={isMenuOpen}
         onClick={() => setIsMenuOpen(false)}
         tabIndex={-1}
+        aria-label={t.closeMenuAria}
       />
-      <S.Sidebar $isOpen={isMenuOpen}>
+      <S.Sidebar $isOpen={isMenuOpen} ref={sidebarRef}>
         <S.MenuCloseButton
           type="button"
           onClick={() => setIsMenuOpen(false)}
           ref={closeButtonRef}
+          aria-label={t.closeMenu}
         >
-          Close menu
+          {t.closeMenu}
         </S.MenuCloseButton>
         <S.SidebarContainer>
           <S.SidebarChildren>
+            <ActiveUserSelector
+              participants={participants}
+              activeUser={activeUser}
+              setActiveUser={setActiveUser}
+            />
+            <SearchMessagesSection />
             <FilterModeSelector
               filterMode={filterMode}
               setFilterMode={setFilterMode}
@@ -112,14 +200,22 @@ function Sidebar() {
                 setMessagesByDate={setMessagesByDate}
               />
             )}
-            <ActiveUserSelector
-              participants={participants}
-              activeUser={activeUser}
-              setActiveUser={setActiveUser}
-            />
-
             <S.Field>
-              <S.Label htmlFor="is-anonymous">Anonymize users</S.Label>
+              <S.Submit
+                type="button"
+                value={t.clearFilters}
+                onClick={handleClearFilters}
+              />
+            </S.Field>
+            <S.Field>
+              <S.Submit
+                type="button"
+                value={t.exportVisible}
+                onClick={handleExportVisible}
+              />
+            </S.Field>
+            <S.Field>
+              <S.Label htmlFor="is-anonymous">{t.anonymizeUsers}</S.Label>
               <S.ToggleCheckbox
                 id="is-anonymous"
                 type="checkbox"

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { useAtom } from 'jotai';
+import styled from 'styled-components';
+import { toastMessageAtom } from '../../stores/toast';
+import { setErrorHandler, defaultErrorHandler } from '../../errorNotifier';
+
+const ToastContainer = styled.div<{ $visible: boolean }>`
+  position: fixed;
+  bottom: 4rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.75rem 1.25rem;
+  background: #333;
+  color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 100;
+  max-width: 90vw;
+  opacity: ${p => (p.$visible ? 1 : 0)};
+  pointer-events: ${p => (p.$visible ? 'auto' : 'none')};
+  transition: opacity 0.2s ease;
+
+  @media (min-width: 700px) {
+    bottom: 5rem;
+  }
+`;
+
+function Toast() {
+  const [message, setMessage] = useAtom(toastMessageAtom);
+
+  useEffect(() => {
+    setErrorHandler((msg: string) => setMessage(msg));
+    return () => setErrorHandler(defaultErrorHandler);
+  }, [setMessage]);
+
+  useEffect(() => {
+    if (!message) return;
+    const id = setTimeout(() => setMessage(null), 5000);
+    return () => clearTimeout(id);
+  }, [message, setMessage]);
+
+  if (!message) return null;
+
+  return (
+    <ToastContainer $visible={!!message} role="alert">
+      {message}
+    </ToastContainer>
+  );
+}
+
+export default Toast;

--- a/src/errorNotifier.ts
+++ b/src/errorNotifier.ts
@@ -1,0 +1,17 @@
+/**
+ * Allows non-React code (e.g. utils) to show errors via toast.
+ * Toast component registers its setState on mount; falls back to alert otherwise.
+ */
+export const defaultErrorHandler = (msg: string) => {
+  // eslint-disable-next-line no-alert
+  if (typeof window !== 'undefined') alert(msg);
+};
+let errorHandler: (message: string) => void = defaultErrorHandler;
+
+export function setErrorHandler(handler: (message: string) => void): void {
+  errorHandler = handler;
+}
+
+export function notifyError(message: string): void {
+  errorHandler(message);
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,78 @@
+/**
+ * Centralized UI strings for easier editing and future i18n.
+ */
+export const t = {
+  // App & header
+  downloadExample: 'Download example chat',
+  or: 'OR',
+  skipToMessages: 'Skip to messages',
+
+  // Dropzone
+  dropzoneLabel:
+    'Click here to upload a file or drag and drop it onto the dashed region',
+  dropzoneFormats: 'supported formats:',
+  txt: 'txt',
+  zip: 'zip',
+
+  // Sidebar
+  openMenu: 'Open menu',
+  closeMenu: 'Close menu',
+  closeMenuAria: 'Close menu (press Escape)',
+
+  // Who are you
+  whoAreYou: 'Who are you?',
+  whoAreYouTitle: 'Select your name so your messages appear on the right',
+  chooseYourName: 'Choose your name…',
+  loadChatFirst: 'Load a chat first',
+  yourMessagesHint: 'Your messages will show on the right; others on the left.',
+
+  // Filter
+  filterBy: 'Filter by',
+  index: 'Index',
+  date: 'Date',
+  messagesLimit: 'Messages limit',
+  start: 'Start',
+  end: 'End',
+  apply: 'Apply',
+  messagesLimitCaution:
+    'A high delta may freeze the page for a while, change this with caution',
+  messagesDateWindow: 'Messages date window',
+  dateRangeCaution: 'A high delta may freeze the page for a while, change this with caution',
+
+  // Search Messages (WhatsApp-style)
+  searchMessagesTitle: 'Search Messages',
+  searchPlaceholder: 'Search by author or text…',
+  searchLabel: 'Search',
+  jumpToDate: 'Jump to date',
+  pickDatePlaceholder: 'Pick a date',
+
+  // Actions
+  clearFilters: 'Clear filters',
+  exportVisible: 'Export visible messages',
+
+  // Anonymize
+  anonymizeUsers: 'Anonymize users',
+
+  // Message viewer
+  showingAll: (n: number) => `Showing all ${n} messages`,
+  showingRange: (low: number, high: number, total: number) =>
+    `Showing messages ${low} to ${high} (${high - low + 1} out of ${total})`,
+  showingDateRange: (start: string, end: string) =>
+    `Showing messages from ${start} to ${end}`,
+  showingSearch: (n: number, query: string) =>
+    `${n} messages matching "${query}"`,
+
+  // Credits
+  madeBy: 'Made by',
+  sourceCode: 'Source code',
+
+  // Scroll
+  scrollToTop: 'Scroll to top',
+
+  // Attachment
+  loadingAttachment: (name: string) => `Loading ${name}...`,
+  chatImage: 'Chat image',
+  chatVideo: 'Chat video',
+  chatAudio: 'Chat audio',
+  closeMediaViewer: 'Close (Escape)',
+} as const;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -61,6 +61,9 @@ export const t = {
     `Showing messages from ${start} to ${end}`,
   showingSearch: (n: number, query: string) =>
     `${n} messages matching "${query}"`,
+  searchResults: 'Search results',
+  searchResultShowInChat: 'Show in conversation',
+  clickToShowInChat: 'Click to show this message in full conversation',
 
   // Credits
   madeBy: 'Made by',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,17 @@
+import { Suspense } from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App';
+import Toast from './components/Toast/Toast';
 
 const rootDOM = document.getElementById('root');
 
 if (rootDOM !== null) {
   const root = ReactDOM.createRoot(rootDOM);
-  root.render(<App />);
+  root.render(
+    <Suspense fallback={<div style={{ padding: '2rem', textAlign: 'center' }}>Loading…</div>}>
+      <App />
+      <Toast />
+    </Suspense>,
+  );
 }

--- a/src/stores/filters.ts
+++ b/src/stores/filters.ts
@@ -3,7 +3,8 @@ import { atom } from 'jotai';
 import { DateBounds, FilterMode, ILimits } from '../types';
 
 const DEFAULT_LOWER_LIMIT = 1;
-const DEFAULT_UPPER_LIMIT = 100;
+/** Large default so all messages are shown until user applies a custom range */
+const DEFAULT_UPPER_LIMIT = 999_999;
 
 const globalFilterModeAtom = atom<FilterMode>('index');
 
@@ -29,4 +30,6 @@ const datesAtom = atom<DateBounds>({
   end: new Date(),
 });
 
-export { globalFilterModeAtom, limitsAtom, datesAtom };
+const searchQueryAtom = atom('');
+
+export { globalFilterModeAtom, limitsAtom, datesAtom, searchQueryAtom };

--- a/src/stores/filters.ts
+++ b/src/stores/filters.ts
@@ -32,4 +32,13 @@ const datesAtom = atom<DateBounds>({
 
 const searchQueryAtom = atom('');
 
-export { globalFilterModeAtom, limitsAtom, datesAtom, searchQueryAtom };
+/** When set, MessageViewer scrolls to the message with this index (in full list) then clears */
+const scrollToMessageIndexAtom = atom<number | null>(null);
+
+export {
+  globalFilterModeAtom,
+  limitsAtom,
+  datesAtom,
+  searchQueryAtom,
+  scrollToMessageIndexAtom,
+};

--- a/src/stores/toast.ts
+++ b/src/stores/toast.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const toastMessageAtom = atom<string | null>(null);

--- a/src/style.ts
+++ b/src/style.ts
@@ -2,10 +2,26 @@ import styled, { createGlobalStyle } from 'styled-components';
 
 import { whatsappThemeColor } from './utils/colors';
 
+const SkipLink = styled.a`
+  position: absolute;
+  top: -100px;
+  left: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: #333;
+  color: white;
+  z-index: 1000;
+  transition: top 0.2s;
+
+  &:focus {
+    top: 0.5rem;
+  }
+`;
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 100%;
+  position: relative;
 `;
 
 const Header = styled.header`
@@ -89,4 +105,4 @@ const GlobalStyles = createGlobalStyle`
   }
 `;
 
-export { GlobalStyles, Container, Header };
+export { GlobalStyles, Container, Header, SkipLink };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,6 +2,7 @@ import JSZip from 'jszip';
 import { parseString } from 'whatsapp-chat-parser';
 import { DateBounds, ExtractedFile, IndexedMessage } from '../types';
 import { UniqueIdGenerator } from './unique-id-generator';
+import { notifyError } from '../errorNotifier';
 
 const getMimeType = (fileName: string) => {
   if (/\.jpe?g$/.test(fileName)) return 'image/jpeg';
@@ -23,7 +24,7 @@ const getMimeType = (fileName: string) => {
 
 const showError = (message: string, err?: Error) => {
   console.error(err || message); // eslint-disable-line no-console
-  alert(message); // eslint-disable-line no-alert
+  notifyError(message);
 };
 
 const readChatFile = (zipData: JSZip) => {
@@ -66,8 +67,7 @@ const fileToText = (file: ExtractedFile) => {
   if (typeof file === 'string') return Promise.resolve(file);
 
   return readChatFile(file).catch((err: Error) => {
-    // eslint-disable-next-line no-alert
-    alert(err);
+    notifyError(err.message || String(err));
     return Promise.resolve('');
   });
 };
@@ -127,6 +127,19 @@ function capitalize(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
+function filterMessagesBySearch(
+  messages: IndexedMessage[],
+  query: string,
+): IndexedMessage[] {
+  if (!query.trim()) return messages;
+  const q = query.trim().toLowerCase();
+  return messages.filter(
+    m =>
+      (m.author && m.author.toLowerCase().includes(q)) ||
+      m.message.toLowerCase().includes(q),
+  );
+}
+
 export {
   getMimeType,
   showError,
@@ -139,5 +152,6 @@ export {
   getISODateString,
   extractStartEndDatesFromMessages,
   filterMessagesByDate,
+  filterMessagesBySearch,
   capitalize,
 };

--- a/src/utils/z-index.ts
+++ b/src/utils/z-index.ts
@@ -1,6 +1,7 @@
 const zIndex = {
   overlay: 10,
   sidebar: 20,
+  mediaViewer: 30,
 };
 
 export { zIndex };

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "build"
+}


### PR DESCRIPTION
### Summary
Fork with UX and feature improvements inspired by WhatsApp: search, jump-to-date, media viewer, and better defaults.

### Added
- **Search Messages** – Search by author or message text with highlight; **Jump to date** calendar to view a specific day
- **Who are you?** – Prominent selector so “your” messages show on the right; choice stored in localStorage
- **Media viewer** – Click images/videos to open in a full-screen lightbox (Escape to close)
- **Improved audio** – `preload="metadata"`, styled container, accessible labels
- **Toast notifications** – In-app toasts instead of `alert()` for errors
- **Export visible messages** – Download current filtered list as `.txt`
- **Clear filters** – One-click reset to show all messages
- **Scroll to top** – Floating button for long chats
- **Virtual list** – react-virtuoso for better performance on long chats
- **Accessibility** – Skip-to-messages link, aria-labels, focus trap in sidebar
- **i18n** – Centralized UI strings in `src/i18n.ts`
- **Vercel** – `vercel.json` with `outputDirectory: build` for deployment

### Changed
- **Show all messages by default** – No more 1–100 limit; full chat until you filter
- **Timestamp layout** – Date/time on its own line below the bubble (WhatsApp-style)
- **Sidebar order** – “Who are you?” and “Search Messages” first

### Changelog
See [CHANGELOG.md](CHANGELOG.md) for version **1.12.0** (2025-03-04).